### PR TITLE
[Suggestion][1.11.2] Aether Logger, Developer Mode, and Auto Developer Mode

### DIFF
--- a/src/main/java/com/legacy/aether/common/Aether.java
+++ b/src/main/java/com/legacy/aether/common/Aether.java
@@ -20,11 +20,15 @@ import com.legacy.aether.common.registry.sounds.SoundsAether;
 import com.legacy.aether.common.tile_entities.AetherTileEntities;
 import com.legacy.aether.common.world.AetherWorld;
 
-@Mod(name = "Aether Legacy", modid = Aether.modid, version = "v1.0.1", acceptedMinecraftVersions = "1.11.2")
+@Mod(name = "Aether Legacy", modid = Aether.modid, version = Aether.version, acceptedMinecraftVersions = "1.11.2")
 public class Aether 
 {
 
 	public static final String modid = "aether_legacy";
+
+	//If version number has "dev" in it, developer mode will automatically be enabled.
+	//This saves time and makes things much easier.
+	public static final String version = "v1.0.1-dev";
 
 	@Instance(Aether.modid)
 	public static Aether instance;
@@ -36,6 +40,7 @@ public class Aether
 	public void preInitialization(FMLPreInitializationEvent event)
 	{
 		AetherConfig.init(event.getModConfigurationDirectory());
+		AetherConfig.autoDeveloperMode(version);
 
 		AetherNetworkingManager.preInitialization();
 

--- a/src/main/java/com/legacy/aether/common/AetherConfig.java
+++ b/src/main/java/com/legacy/aether/common/AetherConfig.java
@@ -16,6 +16,8 @@ public class AetherConfig
 
 	private static boolean skyrootBucketOnly;
 
+	private static boolean developer_mode;
+
 	public static void init(File location)
 	{
 		File newFile = new File(location + "/aether" + "/Aether_Legacy.cfg");
@@ -41,6 +43,8 @@ public class AetherConfig
 		skyrootBucketOnly = config.get("Misc", "Activate portal with only Skyroot bucket", false).getBoolean(false);
 
 		disable_trivia = config.get("Trivia", "Disable random trivia", false).getBoolean(false);
+
+		developer_mode = config.get("Developer Options", "Enable extra logging for certain features", false).getBoolean(false);
 
 		config.save();
 	}
@@ -68,6 +72,20 @@ public class AetherConfig
 	public static boolean activateOnlyWithSkyroot()
 	{
 		return AetherConfig.skyrootBucketOnly;
+	}
+
+	public static void autoDeveloperMode(String versionNumber)
+	{
+		if (versionNumber.contains("dev"))
+		{
+			developer_mode = true;
+			AetherLogger.print("It appears that you are using a development build of Aether Legacy. As such, developer mode has automatically been enabled regardless of configuration setting.");
+		}
+	}
+
+	public static boolean developerMode()
+	{
+		return AetherConfig.developer_mode;
 	}
 
 }

--- a/src/main/java/com/legacy/aether/common/AetherConfig.java
+++ b/src/main/java/com/legacy/aether/common/AetherConfig.java
@@ -74,6 +74,8 @@ public class AetherConfig
 		return AetherConfig.skyrootBucketOnly;
 	}
 
+	//This method should be before the method below, because if it is below the developerMode() boolean method,
+	//I'm assuming that the original configuration developer mode setting will take place regardless of this method.
 	public static void autoDeveloperMode(String versionNumber)
 	{
 		if (versionNumber.contains("dev"))

--- a/src/main/java/com/legacy/aether/common/AetherLogger.java
+++ b/src/main/java/com/legacy/aether/common/AetherLogger.java
@@ -8,6 +8,7 @@ public class AetherLogger
     public static final Logger log = LogManager.getLogger("[Aether Legacy]: ");
     public static final Logger logDev = LogManager.getLogger("[Aether Legacy Developer]: ");
 
+    //Just what you'd expect.
     public static void print(Object message)
     {
         if(message.toString() != null)
@@ -16,6 +17,7 @@ public class AetherLogger
         }
     }
 
+    //This method only prints to console when the developer mode config setting is enabled.
     public static void printDev(Object messageDeveloper)
     {
         if (messageDeveloper.toString() == null)

--- a/src/main/java/com/legacy/aether/common/AetherLogger.java
+++ b/src/main/java/com/legacy/aether/common/AetherLogger.java
@@ -1,0 +1,42 @@
+package com.legacy.aether.common;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class AetherLogger
+{
+    public static final Logger log = LogManager.getLogger("[Aether Legacy]: ");
+    public static final Logger logDev = LogManager.getLogger("[Aether Legacy Developer]: ");
+
+    public static void print(Object message)
+    {
+        if(message.toString() != null)
+        {
+            log.info(message.toString());
+        }
+    }
+
+    public static void printDev(Object messageDeveloper)
+    {
+        if (messageDeveloper.toString() == null)
+        {
+            logDev.info(messageDeveloper.toString());
+        }
+    }
+
+    public static void printWarn(Object messageWarning)
+    {
+        if(messageWarning.toString() != null)
+        {
+            log.warn("[WARNING] " + messageWarning.toString());
+        }
+    }
+
+    public static void printError(Object messageError)
+    {
+        if (messageError.toString() == null)
+        {
+            log.error("[ERROR] ");
+        }
+    }
+}

--- a/src/main/java/com/legacy/aether/common/AetherLogger.java
+++ b/src/main/java/com/legacy/aether/common/AetherLogger.java
@@ -20,7 +20,10 @@ public class AetherLogger
     {
         if (messageDeveloper.toString() == null)
         {
-            logDev.info(messageDeveloper.toString());
+            if(AetherConfig.developerMode())
+            {
+                logDev.info(messageDeveloper.toString());
+            }
         }
     }
 

--- a/src/main/java/com/legacy/aether/common/registry/achievements/AchievementsAether.java
+++ b/src/main/java/com/legacy/aether/common/registry/achievements/AchievementsAether.java
@@ -33,7 +33,8 @@ public class AchievementsAether
 
 		ACpage = new AchievementPage("Aether I", enter_aether, defeat_bronze, defeat_silver, defeat_gold, enchanter, incubator, blue_cloud, flying_pig, grav_tools, loreception);
 
-		AchievementPage.registerAchievementPage(ACpage); AetherLogger.printDev("Achievements successfully registered.");
+		AchievementPage.registerAchievementPage(ACpage);
+		AetherLogger.printDev("Achievements successfully registered."); //Obviously you can delete this later if you want.
 	}
 
 }

--- a/src/main/java/com/legacy/aether/common/registry/achievements/AchievementsAether.java
+++ b/src/main/java/com/legacy/aether/common/registry/achievements/AchievementsAether.java
@@ -1,5 +1,6 @@
 package com.legacy.aether.common.registry.achievements;
 
+import com.legacy.aether.common.AetherLogger;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -32,7 +33,7 @@ public class AchievementsAether
 
 		ACpage = new AchievementPage("Aether I", enter_aether, defeat_bronze, defeat_silver, defeat_gold, enchanter, incubator, blue_cloud, flying_pig, grav_tools, loreception);
 
-		AchievementPage.registerAchievementPage(ACpage);
+		AchievementPage.registerAchievementPage(ACpage); AetherLogger.printDev("Achievements successfully registered.");
 	}
 
 }


### PR DESCRIPTION
Changes I've made:
- Aether Logger is a logging system that prints to the console using the mod's name. For example, anything printed using the `AetherLogger.print(String)` method will show up in the console as `[Aether Legacy]: String`. I have also included printWarn and printError methods.
- Developer Mode is a configuration that, when enabled, will print anything using the `AetherLogger.printDev(String)` method to the console. If developer mode is disabled, the method will still be called, but nothing will print because the IF statement requires developer mode to be enabled.
- Auto Developer Mode is triggered when "dev" is included in the version number. I have changed this pull requests version number to `v1.0.1-dev` for you to try out. In a nutshell, when "dev" is included in the version number, developer mode will automatically be enabled, regardless of the configuration file. You may alter this in whatever way you'd like.
- Thanks for stopping by. Vsauce. Michael out.